### PR TITLE
Partial deep overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unstoppable-mockery",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "ts-jest": "^29.4.1",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"
+  },
+  "dependencies": {
+    "type-fest": "^5.0.1"
   }
 }

--- a/src/mock-class.ts
+++ b/src/mock-class.ts
@@ -1,5 +1,6 @@
-import type { Mocked } from './types';
+import type { PartialDeep } from 'type-fest';
 
+import type { Mocked } from './types';
 /**
  * Creates a mocked version of a class, replacing all prototype methods with jest mock functions.
  *
@@ -26,7 +27,7 @@ import type { Mocked } from './types';
  */
 export function mockClass<T>(
   template: new (...args: any[]) => T,
-  properties: Partial<T> = {},
+  properties?: PartialDeep<T>,
 ): Mocked<T> {
   const mockedObject = Object.getOwnPropertyNames(template.prototype).reduce(
     (prev, current) => {

--- a/src/mock-interface.ts
+++ b/src/mock-interface.ts
@@ -1,3 +1,5 @@
+import type { PartialDeep } from 'type-fest';
+
 import type { Mocked } from './types';
 
 /**
@@ -24,12 +26,12 @@ import type { Mocked } from './types';
  * @returns A mocked object based on an interface or class type
  */
 export function mockInterface<T extends object>(
-  overrides?: Partial<T>,
+  overrides?: PartialDeep<T>,
 ): Mocked<T> {
   return new Proxy({} as Mocked<T>, {
     get: (target, name) => {
       if (overrides && name in overrides) {
-        return overrides[name as keyof T];
+        return overrides[name as keyof PartialDeep<T>];
       }
 
       if (
@@ -43,4 +45,3 @@ export function mockInterface<T extends object>(
     },
   });
 }
-//

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,6 +2822,11 @@ synckit@^0.11.7, synckit@^0.11.8:
   dependencies:
     "@pkgr/core" "^0.2.9"
 
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -2889,6 +2894,13 @@ type-fest@^4.41.0:
   version "4.41.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
+type-fest@^5.0.1:
+  version "5.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/type-fest/-/type-fest-5.0.1.tgz#546c87966765f88f4f36e0521be4b3d0215b4cab"
+  integrity sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 typescript-eslint@^8.39.0:
   version "8.39.1"


### PR DESCRIPTION
Make it easier to supply overrides to `mockClass` and `mockInterface` by declaring their types as `PartialDeep` from `type-fest`. 