### PR TITLE
chore: rename package to @atlassian/unstoppable-mockery and publish via Artifactory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,6 @@ jobs:
           output-modes: npm
 
       - name: Publish to Artifactory npm-public
-        run: npm publish --userconfig=./.npmrc-public --@atlassian:registry="https://packages.atlassian.com/api/npm/npm-public/"
+        run: npm publish
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: 24
           cache: 'yarn'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -31,7 +30,11 @@ jobs:
       - name: Build package
         run: yarn build
 
-      - name: Publish to NPM
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Get Artifact Publish Token
+        id: publish-token
+        uses: atlassian-labs/artifact-publish-token@v1.0.1
+        with:
+          output-modes: npm
+
+      - name: Publish to Artifactory npm-public
+        run: npm publish --userconfig=./.npmrc-public --@atlassian:registry="https://packages.atlassian.com/api/npm/npm-public/"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unstoppable-mockery
+# @atlassian/unstoppable-mockery
 
 [![Atlassian license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 
@@ -9,7 +9,7 @@ Unstoppable Mockery is a lightweight utility for creating type-safe, fully mocke
 ### Mocking Classes
 
 ```typescript
-import { mockClass } from 'unstoppable-mockery';
+import { mockClass } from '@atlassian/unstoppable-mockery';
 
 class MyService {
   doSomething() { /* ... */ }
@@ -28,7 +28,7 @@ expect(mock.getValue()).toBe(100);
 ### Mocking Interfaces
 
 ```typescript
-import { mockInterface } from 'unstoppable-mockery';
+import { mockInterface } from '@atlassian/unstoppable-mockery';
 
 interface ApiClient {
   fetchData: (id: string) => Promise<any>;
@@ -58,7 +58,7 @@ expect(jest.isMockFunction(mockApi.fetchData)).toBe(true);
 ## Installation
 
 ```sh
-npm install unstoppable-mockery --save-dev
+npm install @atlassian/unstoppable-mockery --save-dev
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unstoppable-mockery",
+  "name": "@atlassian/unstoppable-mockery",
   "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,6 +16,9 @@
     "mockito"
   ],
   "private": false,
+  "publishConfig": {
+    "registry": "https://packages.atlassian.com/api/npm/npm-public/"
+  },
   "contributors": [
     {
       "name": "Daniel Hreben",


### PR DESCRIPTION
Renames the package from `unstoppable-mockery` to `@atlassian/unstoppable-mockery` as part of VULN-1921018 remediation.\n\n## Changes\n- Rename `name` in `package.json` to `@atlassian/unstoppable-mockery`\n- Add `publishConfig` pointing to Artifactory `npm-public`\n- Switch `release.yml` from direct npmjs publish to `artifact-publish-token`\n- Update README install instructions and import examples\n\n## Follow-up\n- BENGHELP ticket will be raised to allowlist `@atlassian/unstoppable-mockery` in `npm-public`\n- Old `unstoppable-mockery` will be deprecated on npmjs.org pointing to this package